### PR TITLE
Clarify ref start window

### DIFF
--- a/R/derive_param_bor.R
+++ b/R/derive_param_bor.R
@@ -102,8 +102,9 @@
 #' @param ref_start_window Stable disease time window
 #'
 #'   The ref_start_window is used along with `reference_date` to determine those
-#'   records that occur before and after `ADT` (see Details section for further
-#'   information).
+#'   records that occur before and after `ADT` (i.e. for a record determine 
+#'   whether `ADT` >= `reference_date` + `ref_start_window`), 
+#'   see Details section for further information.
 #'
 #'   *Permitted Values:* a non-negative numeric scalar
 #'

--- a/R/derive_param_confirmed_bor.R
+++ b/R/derive_param_confirmed_bor.R
@@ -55,7 +55,8 @@
 #'
 #' @param ref_start_window Stable disease time window
 #'
-#'   Assessments at least the specified number of days after the reference date
+#'   Assessments at least the specified number of days after the reference date 
+#'   (i.e. where `ADT` >= `reference_date` + `ref_start_window`)
 #'   with response `"CR"`, `"PR"`, `"SD"`, or `"NON-CR/NON-PD"` are considered
 #'   for `"SD"` or `"NON-CR/NON-PD"` response.
 #'

--- a/man/derive_param_bor.Rd
+++ b/man/derive_param_bor.Rd
@@ -89,8 +89,9 @@ randomization date (\code{RANDDT}).
 \item{ref_start_window}{Stable disease time window
 
 The ref_start_window is used along with \code{reference_date} to determine those
-records that occur before and after \code{ADT} (see Details section for further
-information).
+records that occur before and after \code{ADT} (i.e. for a record determine
+whether \code{ADT} >= \code{reference_date} + \code{ref_start_window}),
+see Details section for further information.
 
 \emph{Permitted Values:} a non-negative numeric scalar
 

--- a/man/derive_param_confirmed_bor.Rd
+++ b/man/derive_param_confirmed_bor.Rd
@@ -76,6 +76,7 @@ start date (\code{TRTSDT}) or randomization date (\code{RANDDT}).
 \item{ref_start_window}{Stable disease time window
 
 Assessments at least the specified number of days after the reference date
+(i.e. where \code{ADT} >= \code{reference_date} + \code{ref_start_window})
 with response \code{"CR"}, \code{"PR"}, \code{"SD"}, or \code{"NON-CR/NON-PD"} are considered
 for \code{"SD"} or \code{"NON-CR/NON-PD"} response.
 


### PR DESCRIPTION
Closes #83.

Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/articles/development_process.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the admiral codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/) 
- [x] Updated relevant unit tests or have written new unit tests - See [Unit Test Guide](https://pharmaverse.github.io/admiral/articles/unit_test_guidance.html#writing-unit-tests-in-admiral-)
- [x] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiral/articles/programming_strategy.html#deprecation-1)?
- [x] Update to all relevant roxygen headers and examples 
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Address any updates needed for vignettes and/or templates
- [x] Update `NEWS.md`
- [x] Build admiral site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/admiralonco/reference/index.html)" page. 
- [x] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue so that it closes after successful merging. 
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!
