### PR TITLE
Update .Rprofile that fix R CMD check

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,5 @@
-source("renv/activate.R")
+if (Sys.getenv("GITHUB_ACTIONS") == "" || (Sys.getenv("GITHUB_ACTIONS") == "true" && getRversion()$major == 3 && getRversion()$minor == 6)) {
+  source("renv/activate.R")
+} else {
+  options(repos = c(CRAN = "https://cran.rstudio.com"))
+}


### PR DESCRIPTION
This PR should fix the problem with R CMD check.

It was using the `.Rprofile` that was not excluded renv activation from GITHUB_ACTION when running the stage dependencies.